### PR TITLE
Add convenience generator to creates nodes by hostname

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -2,8 +2,11 @@
 package snowflake
 
 import (
+	"crypto/md5"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -48,6 +51,20 @@ func NewNode(node int64) (*Node, error) {
 		node: node,
 		step: 0,
 	}, nil
+}
+
+// NewNodeByHostname is a convenience method which creates a new Node based
+// off a hash of the machine's hostname.
+func NewNodeByHostname() (*Node, error) {
+	name, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	hash := md5.Sum([]byte(name))
+	id := binary.BigEndian.Uint64(hash[:]) & 0x3FF // mask to first 10 bits, max of 1023
+
+	return NewNode(int64(id))
 }
 
 // Generate creates and returns a unique snowflake ID

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -2,6 +2,18 @@ package snowflake
 
 import "testing"
 
+func TestGeneratesWithHostname(t *testing.T) {
+	// quick sanity test, nothing too crazy...
+	node, err := NewNodeByHostname()
+	if err != nil {
+		t.Error("Unexpected error creating node by hostname")
+	}
+
+	if node.node == 0 {
+		t.Error("Expected non-zero ID to be assigned by NewNodeByHostname")
+	}
+}
+
 func TestMarshalJSON(t *testing.T) {
 	id := ID(13587)
 	expected := "\"13587\""


### PR DESCRIPTION
Adds a quick `NewNodeByHostname()` function which assigns an ID based off a hash of the hostname. Not 100% super duper safe but good for smaller clusters (< 38 nodes, at which point the chance of two nodes having the same ID exceeds 50%) or clusters where consensus is not immediately available.