### PR TITLE
Add a method to encode the snowflake as a byte slice

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -3,6 +3,7 @@ package snowflake
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"strconv"
 	"sync"
@@ -105,9 +106,17 @@ func (f ID) Base64() string {
 	return base64.StdEncoding.EncodeToString(f.Bytes())
 }
 
-// Bytes returns a byte array of the snowflake ID
+// Bytes returns a byte slice of the snowflake ID
 func (f ID) Bytes() []byte {
 	return []byte(f.String())
+}
+
+// IntBytes returns an array of bytes of the snowflake ID, encoded as a
+// big endian integer.
+func (f ID) IntBytes() [8]byte {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(f))
+	return b
 }
 
 // Time returns an int64 unix timestamp of the snowflake ID time

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -1,6 +1,9 @@
 package snowflake
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestMarshalJSON(t *testing.T) {
 	id := ID(13587)
@@ -13,6 +16,14 @@ func TestMarshalJSON(t *testing.T) {
 
 	if string(bytes) != expected {
 		t.Errorf("Got %s, expected %s", string(bytes), expected)
+	}
+}
+
+func TestMarshalsIntBytes(t *testing.T) {
+	id := ID(13587).IntBytes()
+	expected := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x35, 0x13}
+	if !bytes.Equal(id[:], expected) {
+		t.Errorf("Expected ID to be encoded as %v, got %v", expected, id)
 	}
 }
 


### PR DESCRIPTION
Previously there was a method called `Bytes() []byte`, but that simply returned the string representation as a byte slice. Not too efficient for storage and transport. This PR adds a method which returns a raw representation of the ID as an 8-bit byte array.

Also marshalling it into a byte array is ~10x faster than the JSON marshaller, since it looks like you folks like benchmarks 😉 

```
BenchmarkMarshal-4   	10000000	       172 ns/op	      32 B/op	       1 allocs/op
BenchmarkIntMarshal-4	100000000	        17.1 ns/op	       0 B/op	       0 allocs/op
```