### PR TITLE
Update error log for wrong node id.

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -90,7 +90,7 @@ type ID int64
 func NewNode(node int64) (*Node, error) {
 
 	if node < 0 || node > nodeMax {
-		return nil, errors.New("Node number must be between 0 and 1023")
+		return nil, errors.New("Node number must be between 0 and " + strconv.Itoa(nodeMax))
 	}
 
 	// re-calc in case custom NodeBits or StepBits were set


### PR DESCRIPTION
Update error log for wrong node id for nodeMax not always equal 1023.