### PR TITLE
Use Monotonic clock

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -108,14 +108,14 @@ func (n *Node) Generate() ID {
 
 	n.mu.Lock()
 
-	now := time.Now()
+	now := time.Now().Round(time.Millisecond)
 
 	if now.Sub(n.time) < time.Millisecond {
 		n.step = (n.step + 1) & stepMask
 
 		if n.step == 0 {
 			for now.Sub(n.time) < time.Millisecond {
-				now = time.Now()
+				now = time.Now().Round(time.Millisecond)
 			}
 		}
 	} else {

--- a/snowflake.go
+++ b/snowflake.go
@@ -12,9 +12,11 @@ import (
 )
 
 var (
+	curTime = time.Now()
 	// Epoch is set to the twitter snowflake epoch of Nov 04 2010 01:42:54 UTC
 	// You may customize this to set a different epoch for your application.
-	Epoch = time.Date(2010, time.November, 4, 1, 42, 54, 0, time.UTC)
+	// Note: add time.Duration to time.Now() to make sure we use the monotonic clock if available.
+	Epoch = curTime.Add(time.Date(2010, time.November, 4, 1, 42, 54, 0, time.UTC).Sub(curTime))
 
 	// Number of bits to use for Node
 	// Remember, you have a total 22 bits to share between Node/Step
@@ -108,14 +110,14 @@ func (n *Node) Generate() ID {
 
 	n.mu.Lock()
 
-	now := time.Now().Sub(Epoch)
+	now := time.Since(Epoch)
 
 	if now-n.time < time.Millisecond {
 		n.step = (n.step + 1) & stepMask
 
 		if n.step == 0 {
 			for now-n.time < time.Millisecond {
-				now = time.Now().Sub(Epoch)
+				now = time.Since(Epoch)
 			}
 		}
 	} else {

--- a/snowflake.go
+++ b/snowflake.go
@@ -100,11 +100,7 @@ func NewNode(node int64) (*Node, error) {
 		return nil, errors.New("Node number must be between 0 and " + strconv.FormatInt(nodeMax, 10))
 	}
 
-	return &Node{
-		// time: 0,
-		node: node,
-		step: 0,
-	}, nil
+	return &Node{node: node}, nil
 }
 
 // Generate creates and returns a unique snowflake ID

--- a/snowflake.go
+++ b/snowflake.go
@@ -76,7 +76,7 @@ var ErrInvalidBase32 = errors.New("invalid base32")
 // node
 type Node struct {
 	mu   sync.Mutex
-	time time.Time
+	time time.Duration
 	node int64
 	step int64
 }
@@ -108,14 +108,14 @@ func (n *Node) Generate() ID {
 
 	n.mu.Lock()
 
-	now := time.Now().Round(time.Millisecond)
+	now := time.Now().Sub(Epoch)
 
-	if now.Sub(n.time) < time.Millisecond {
+	if now-n.time < time.Millisecond {
 		n.step = (n.step + 1) & stepMask
 
 		if n.step == 0 {
-			for now.Sub(n.time) < time.Millisecond {
-				now = time.Now().Round(time.Millisecond)
+			for now-n.time < time.Millisecond {
+				now = time.Now().Sub(Epoch)
 			}
 		}
 	} else {
@@ -124,7 +124,7 @@ func (n *Node) Generate() ID {
 
 	n.time = now
 
-	r := ID((now.Sub(Epoch).Nanoseconds()/1000000)<<timeShift |
+	r := ID((now.Nanoseconds()/1000000)<<timeShift |
 		(n.node << nodeShift) |
 		(n.step),
 	)


### PR DESCRIPTION
Starting from Go 1.9, the standard time package transparently uses [Monotonic Clocks](https://golang.org/pkg/time/#hdr-Monotonic_Clocks) when available. Let's use that for generating ids to safeguard against wall clock backwards movement which could be caused by time drifts or leap seconds.

This PR addresses the aforementioned issue which may lead to collisions.