### PR TITLE
Remove deprecated

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ package snowflake
 // You may use Config to customize this to set a different epoch for your application.
 const defaultEpoch = 1288834974657
 
+// Config can be used to specify parameters for a Node.
 type Config struct {
 	// Epoch from which the time-part of the ID is offset
 	Epoch int64

--- a/config.go
+++ b/config.go
@@ -1,0 +1,24 @@
+package snowflake
+
+// The default epoch is set to the twitter snowflake epoch of Nov 04 2010 01:42:54 UTC in milliseconds
+// You may use Config to customize this to set a different epoch for your application.
+const defaultEpoch = 1288834974657
+
+type Config struct {
+	// Epoch from which the time-part of the ID is offset
+	Epoch int64
+
+	// NodeBits holds the number of bits to use for Node
+	// Remember, you have a total 22 bits to share between Node/Step
+	NodeBits uint8
+
+	// StepBits holds the number of bits to use for Step
+	// Remember, you have a total 22 bits to share between Node/Step
+	StepBits uint8
+}
+
+var defaultConfig = Config{
+	Epoch:    defaultEpoch,
+	NodeBits: 10,
+	StepBits: 12,
+}

--- a/node.go
+++ b/node.go
@@ -1,0 +1,84 @@
+package snowflake
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// A Node struct holds the basic information needed for a snowflake generator
+// node
+type Node struct {
+	mu    sync.Mutex
+	epoch time.Time
+	time  int64
+	node  int64
+	step  int64
+
+	nodeMax   int64
+	nodeMask  int64
+	stepMask  int64
+	timeShift uint8
+	nodeShift uint8
+}
+
+// NewNodeWithConfig creates a new snowflake node with the given config
+func NewNodeWithConfig(node int64, c Config) (*Node, error) {
+	n := Node{}
+	n.node = node
+	n.nodeMax = -1 ^ (-1 << c.NodeBits)
+	n.nodeMask = n.nodeMax << c.StepBits
+	n.stepMask = -1 ^ (-1 << c.StepBits)
+	n.timeShift = c.NodeBits + c.StepBits
+	n.nodeShift = c.StepBits
+
+	if n.node < 0 || n.node > n.nodeMax {
+		return nil, errors.New("Node number must be between 0 and " + strconv.FormatInt(n.nodeMax, 10))
+	}
+
+	var curTime = time.Now()
+	// add time.Duration to curTime to make sure we use the monotonic clock if available
+	n.epoch = curTime.Add(time.Unix(c.Epoch/1000, (c.Epoch%1000)*1000000).Sub(curTime))
+
+	return &n, nil
+}
+
+// NewNode returns a new snowflake node that can be used to generate snowflake
+// IDs
+func NewNode(node int64) (*Node, error) {
+	return NewNodeWithConfig(node, defaultConfig)
+}
+
+// Generate creates and returns a unique snowflake ID
+// To help guarantee uniqueness
+// - Make sure your system is keeping accurate system time
+// - Make sure you never have multiple nodes running with the same node ID
+func (n *Node) Generate() ID {
+
+	n.mu.Lock()
+
+	now := time.Since(n.epoch).Nanoseconds() / 1000000
+
+	if now == n.time {
+		n.step = (n.step + 1) & n.stepMask
+
+		if n.step == 0 {
+			for now <= n.time {
+				now = time.Since(n.epoch).Nanoseconds() / 1000000
+			}
+		}
+	} else {
+		n.step = 0
+	}
+
+	n.time = now
+
+	r := ID((now)<<n.timeShift |
+		(n.node << n.nodeShift) |
+		(n.step),
+	)
+
+	n.mu.Unlock()
+	return r
+}

--- a/snowflake.go
+++ b/snowflake.go
@@ -7,32 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
-	"time"
 )
-
-// The default epoch is set to the twitter snowflake epoch of Nov 04 2010 01:42:54 UTC in milliseconds
-// You may use Config to customize this to set a different epoch for your application.
-const defaultEpoch = 1288834974657
-
-type Config struct {
-	// Epoch from which the time-part of the ID is offset
-	Epoch int64
-
-	// NodeBits holds the number of bits to use for Node
-	// Remember, you have a total 22 bits to share between Node/Step
-	NodeBits uint8
-
-	// StepBits holds the number of bits to use for Step
-	// Remember, you have a total 22 bits to share between Node/Step
-	StepBits uint8
-}
-
-var defaultConfig = Config{
-	Epoch:    defaultEpoch,
-	NodeBits: 10,
-	StepBits: 12,
-}
 
 const encodeBase32Map = "ybndrfg8ejkmcpqxot1uwisza345h769"
 
@@ -76,85 +51,9 @@ func init() {
 	}
 }
 
-// A Node struct holds the basic information needed for a snowflake generator
-// node
-type Node struct {
-	mu    sync.Mutex
-	epoch time.Time
-	time  int64
-	node  int64
-	step  int64
-
-	nodeMax   int64
-	nodeMask  int64
-	stepMask  int64
-	timeShift uint8
-	nodeShift uint8
-}
-
 // An ID is a custom type used for a snowflake ID.  This is used so we can
 // attach methods onto the ID.
 type ID int64
-
-// NewNodeWithConfig creates a new snowflake node with the given config
-func NewNodeWithConfig(node int64, c Config) (*Node, error) {
-	n := Node{}
-	n.node = node
-	n.nodeMax = -1 ^ (-1 << c.NodeBits)
-	n.nodeMask = n.nodeMax << c.StepBits
-	n.stepMask = -1 ^ (-1 << c.StepBits)
-	n.timeShift = c.NodeBits + c.StepBits
-	n.nodeShift = c.StepBits
-
-	if n.node < 0 || n.node > n.nodeMax {
-		return nil, errors.New("Node number must be between 0 and " + strconv.FormatInt(n.nodeMax, 10))
-	}
-
-	var curTime = time.Now()
-	// add time.Duration to curTime to make sure we use the monotonic clock if available
-	n.epoch = curTime.Add(time.Unix(c.Epoch/1000, (c.Epoch%1000)*1000000).Sub(curTime))
-
-	return &n, nil
-}
-
-// NewNode returns a new snowflake node that can be used to generate snowflake
-// IDs
-func NewNode(node int64) (*Node, error) {
-	return NewNodeWithConfig(node, defaultConfig)
-}
-
-// Generate creates and returns a unique snowflake ID
-// To help guarantee uniqueness
-// - Make sure your system is keeping accurate system time
-// - Make sure you never have multiple nodes running with the same node ID
-func (n *Node) Generate() ID {
-
-	n.mu.Lock()
-
-	now := time.Since(n.epoch).Nanoseconds() / 1000000
-
-	if now == n.time {
-		n.step = (n.step + 1) & n.stepMask
-
-		if n.step == 0 {
-			for now <= n.time {
-				now = time.Since(n.epoch).Nanoseconds() / 1000000
-			}
-		}
-	} else {
-		n.step = 0
-	}
-
-	n.time = now
-
-	r := ID((now)<<n.timeShift |
-		(n.node << n.nodeShift) |
-		(n.step),
-	)
-
-	n.mu.Unlock()
-	return r
-}
 
 // Int64 returns an int64 of the snowflake ID
 func (f ID) Int64() int64 {

--- a/snowflake.go
+++ b/snowflake.go
@@ -34,7 +34,7 @@ var ErrInvalidBase32 = errors.New("invalid base32")
 // This speeds up the process tremendously.
 func init() {
 
-	for i := 0; i < len(encodeBase58Map); i++ {
+	for i := 0; i < len(decodeBase58Map); i++ {
 		decodeBase58Map[i] = 0xFF
 	}
 
@@ -42,7 +42,7 @@ func init() {
 		decodeBase58Map[encodeBase58Map[i]] = byte(i)
 	}
 
-	for i := 0; i < len(encodeBase32Map); i++ {
+	for i := 0; i < len(decodeBase32Map); i++ {
 		decodeBase32Map[i] = 0xFF
 	}
 

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -327,13 +327,13 @@ func TestMarshalJSON(t *testing.T) {
 	id := ID(13587)
 	expected := "\"13587\""
 
-	bytes, err := id.MarshalJSON()
+	json, err := id.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Unexpected error during MarshalJSON")
 	}
 
-	if string(bytes) != expected {
-		t.Fatalf("Got %s, expected %s", string(bytes), expected)
+	if string(json) != expected {
+		t.Fatalf("Got %s, expected %s", string(json), expected)
 	}
 }
 
@@ -453,14 +453,14 @@ func BenchmarkUnmarshal(b *testing.B) {
 	// Generate the ID to unmarshal
 	node, _ := NewNode(1)
 	id := node.Generate()
-	bytes, _ := id.MarshalJSON()
+	json, _ := id.MarshalJSON()
 
 	var id2 ID
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = id2.UnmarshalJSON(bytes)
+		_ = id2.UnmarshalJSON(json)
 	}
 }
 
@@ -473,5 +473,39 @@ func BenchmarkMarshal(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		_, _ = id.MarshalJSON()
+	}
+}
+
+func TestParseBase32(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		want    ID
+		wantErr bool
+	}{
+		{
+			name:    "ok",
+			arg:     "b8wjm1zroyyyy",
+			want:    1427970479175499776,
+			wantErr: false,
+		},
+		{
+			name:    "ok",
+			arg:     "b8wjm1zroyyyyA",
+			want:    -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseBase32([]byte(tt.arg))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseBase32() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseBase32() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -436,9 +436,10 @@ func BenchmarkGenerate(b *testing.B) {
 
 func BenchmarkGenerateMaxSequence(b *testing.B) {
 
-	NodeBits = 1
-	StepBits = 21
-	node, _ := NewNode(1)
+	node, _ := NewNodeWithConfig(1, Config{
+		NodeBits: 1,
+		StepBits: 21,
+	})
 
 	b.ReportAllocs()
 


### PR DESCRIPTION
This removes some of the deprecated config elements by making use of a config object.

I have also removed some methods since keeping them would require making those aware of config; they were already marked for deprecation.

While doing the work I noticed a bug in the way encoding maps were setup, which I have fixed as well.

I have also sliced up the file since snowflake.go was growing longer.