### PR TITLE
Remove deprecated parts of code

### DIFF
--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -436,9 +436,10 @@ func BenchmarkGenerate(b *testing.B) {
 
 func BenchmarkGenerateMaxSequence(b *testing.B) {
 
-	NodeBits = 1
-	StepBits = 21
-	node, _ := NewNode(1)
+	node, _ := NewNodeWithConfig(1, Config{
+		NodeBits: 1,
+		StepBits: 21,
+	})
 
 	b.ReportAllocs()
 


### PR DESCRIPTION
These are backward compatibility breaking changes WRT the config aspect. If the client-code does not specify Epoch, NodeBits or StepBits then there is very little ill effect.

Wraps all node config into a config object and moves global settings into a private global config object.