### PR TITLE
fix: overflow in ParseBase58/ParseBase32

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -230,6 +230,10 @@ func ParseBase32(b []byte) (ID, error) {
 			return -1, ErrInvalidBase32
 		}
 		id = id*32 + int64(decodeBase32Map[b[i]])
+		if id <= 0 {
+			// overflow!
+			return -1, ErrInvalidBase32
+		}
 	}
 
 	return ID(id), nil
@@ -277,6 +281,10 @@ func ParseBase58(b []byte) (ID, error) {
 			return -1, ErrInvalidBase58
 		}
 		id = id*58 + int64(decodeBase58Map[b[i]])
+		if id <= 0 {
+			// overflow!
+			return -1, ErrInvalidBase58
+		}
 	}
 
 	return ID(id), nil

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -512,6 +512,12 @@ func TestParseBase32(t *testing.T) {
 			want:    -1,
 			wantErr: true,
 		},
+		{
+			name:    "overflow is invalid",
+			arg:     "byyyyyyyyyyyyy",
+			want:    -1,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -564,7 +570,14 @@ func TestParseBase58(t *testing.T) {
 			want:    -1,
 			wantErr: true,
 		},
+		{
+			name:    "overflow is invalid",
+			arg:     "JPwcyDCgEuq",
+			want:    -1,
+			wantErr: true,
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseBase58([]byte(tt.arg))


### PR DESCRIPTION
Fixes #42

The ID should not be allowed to overflow an int64. The test cases added here fail before the code change.