### PR TITLE
feat: check Node/Step is ok

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -99,6 +99,9 @@ type ID int64
 // IDs
 func NewNode(node int64) (*Node, error) {
 
+	if NodeBits+StepBits > 22 {
+		return nil, errors.New("Remember, you have a total 22 bits to share between Node/Step")
+	}
 	// re-calc in case custom NodeBits or StepBits were set
 	// DEPRECATED: the below block will be removed in a future release.
 	mu.Lock()


### PR DESCRIPTION
It should be forced to detect that the number of digits of Note and Step does not exceed 22. If only one of them is modified, it will cause problems.
I think this should be mandatory detection