### PR TITLE
opt: clock rollback

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -152,6 +152,10 @@ func (n *Node) Generate() ID {
 		}
 	} else {
 		n.step = 0
+		for now <= n.time { //clock move black
+			time.Sleep(time.Millisecond * time.Duration(n.time-now))
+			now = time.Since(n.epoch).Milliseconds()
+		}
 	}
 
 	n.time = now

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -58,6 +58,21 @@ func TestRace(t *testing.T) {
 
 }
 
+func TestClockMoveDuplicateID(t *testing.T) {
+	node, _ := NewNode(10)
+	Ids := make(map[ID]int, 0)
+	for i := 0; i < 4000; i++ {
+		if i == 2000 {
+			node.time = node.time + 5 //clock move 5ms
+		}
+		x := node.Generate()
+		Ids[x]++
+		if Ids[x] >= 2 {
+			t.Errorf("x(%d) & count(%d) colock black clash", x, Ids[x])
+		}
+	}
+}
+
 //******************************************************************************
 // Converters/Parsers Test funcs
 // We should have funcs here to test conversion both ways for everything


### PR DESCRIPTION
test just clock rollback 5 ms Duplicate ID count 149, 
simply not available in a cloud-native environment....
an idea for not breaking the api !!!


