### PR TITLE
Allow unmarshalling snowflake ID without double quotes

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -354,13 +354,13 @@ func (f ID) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON converts a json byte array of a snowflake ID into an ID type.
 func (f *ID) UnmarshalJSON(b []byte) error {
-	if len(b) < 3 || b[0] != '"' || b[len(b)-1] != '"' {
-		return JSONSyntaxError{b}
+	if len(b) >= 3 && b[0] == '"' && b[len(b)-1] == '"' {
+		b = b[1 : len(b)-1]
 	}
 
-	i, err := strconv.ParseInt(string(b[1:len(b)-1]), 10, 64)
+	i, err := strconv.ParseInt(string(b), 10, 64)
 	if err != nil {
-		return err
+		return JSONSyntaxError{b}
 	}
 
 	*f = ID(i)

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -352,7 +352,14 @@ func TestUnmarshalJSON(t *testing.T) {
 		expectedErr error
 	}{
 		{`"13587"`, 13587, nil},
-		{`1`, 0, JSONSyntaxError{[]byte(`1`)}},
+		{`1`, 1, nil},
+		{`12`, 12, nil},
+		{`13587`, 13587, nil},
+		{``, 0, JSONSyntaxError{[]byte(``)}},
+		{`"1`, 0, JSONSyntaxError{[]byte(`"1`)}},
+		{`1"`, 0, JSONSyntaxError{[]byte(`1"`)}},
+		{`12"`, 0, JSONSyntaxError{[]byte(`12"`)}},
+		{`"12`, 0, JSONSyntaxError{[]byte(`"12`)}},
 		{`"invalid`, 0, JSONSyntaxError{[]byte(`"invalid`)}},
 	}
 


### PR DESCRIPTION
Numbers smaller than 2^53 - 1 can be jsonified without quotes, so UnmarshallJSON shouldn't through errors merely because the byte array does not start and end with `"`