### PR TITLE
Introduce node ID synchronizer and time synchronizer

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,15 @@
+package snowflake
+
+// NodeIdAllocator node id allocator Issue 1: NodeId collision prevention
+type NodeIdAllocator interface {
+	// Alloc allocates node ID
+	Alloc() (nodeId int64, err error)
+	// Drift node ID
+	Drift(nodeId int64) (newNodeId int64, err error)
+}
+
+// TimeSynchronizer time synchronizer Issue 2: Prevent large clock rollback when restarting snowflake ID
+type TimeSynchronizer interface {
+	// Async synchronizes time This method does not report errors, reducing external component dependencies and increasing robustness
+	Async(time int64)
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,25 @@
+package snowflake
+
+type Option struct {
+	// node id allocator
+	allocator NodeIdAllocator
+	// time synchronizer
+	synchronizer TimeSynchronizer
+}
+
+// OptionFn option function
+type OptionFn func(op *Option)
+
+// WithNodeIdAllocator sets node id allocator
+func WithNodeIdAllocator(allocator NodeIdAllocator) func(op *Option) {
+	return func(op *Option) {
+		op.allocator = allocator
+	}
+}
+
+// WithTimeSynchronizer sets time synchronizer
+func WithTimeSynchronizer(synchronizer TimeSynchronizer) func(op *Option) {
+	return func(op *Option) {
+		op.synchronizer = synchronizer
+	}
+}

--- a/snowflake.go
+++ b/snowflake.go
@@ -89,6 +89,42 @@ type Node struct {
 	stepMask  int64
 	timeShift uint8
 	nodeShift uint8
+
+	// allocator node id allocator
+	allocator NodeIdAllocator
+	// synchronizer time synchronizer recommended to use async operations
+	synchronizer TimeSynchronizer
+}
+
+// NewWithOption creates a node based on options
+func NewWithOption(options ...OptionFn) (*Node, error) {
+	op := &Option{}
+	for _, option := range options {
+		option(op)
+	}
+
+	var (
+		allocator    = op.allocator
+		synchronizer = op.synchronizer
+	)
+	if allocator == nil {
+		return nil, errors.New("allocator is not nil")
+	}
+
+	nodeId, err := allocator.Alloc()
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := NewNode(nodeId)
+	if err != nil {
+		return nil, err
+	}
+
+	node.allocator = allocator
+	node.synchronizer = synchronizer
+
+	return node, nil
 }
 
 // An ID is a custom type used for a snowflake ID.  This is used so we can
@@ -160,6 +196,11 @@ func (n *Node) Generate() ID {
 		(n.node << n.nodeShift) |
 		(n.step),
 	)
+
+	// Synchronize time
+	if n.synchronizer != nil {
+		n.synchronizer.Async(r.Time())
+	}
 
 	return r
 }

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -578,3 +578,72 @@ func TestParseBase58(t *testing.T) {
 		})
 	}
 }
+
+func TestNewWithOption(t *testing.T) {
+	allocator := new(testNodeIdAllocator)
+	synchronizer := new(testTimeSynchronizer)
+	type args struct {
+		options []OptionFn
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Node
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			args: args{
+				options: []OptionFn{
+					WithNodeIdAllocator(allocator),
+					WithTimeSynchronizer(synchronizer),
+				},
+			},
+			want: &Node{
+				allocator:    allocator,
+				synchronizer: synchronizer,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no synchronizer",
+			args: args{
+				options: []OptionFn{
+					WithNodeIdAllocator(allocator),
+				},
+			},
+			want: &Node{
+				allocator: allocator,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewWithOption(tt.args.options...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewWithOption() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got.allocator, tt.want.allocator) {
+				t.Errorf("NewWithOption() allocator got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got.synchronizer, tt.want.synchronizer) {
+				t.Errorf("NewWithOption() synchronizer got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testTimeSynchronizer struct {
+}
+
+func (t testTimeSynchronizer) Async(_ int64) {
+	return
+}
+
+type testNodeIdAllocator struct{}
+
+func (t testNodeIdAllocator) Alloc() (nodeId int64, err error) {
+	return 1, nil
+}


### PR DESCRIPTION
Resolve the following issues:

Problem 1: NodeID Collision Prevention NodeID is allocated by a third-party medium, which can resolve NodeID collision issues.

Problem 2: Clock Backward Detection After Restart Since [bwmarrin/snowflake](https://github.com/bwmarrin/snowflake) is based on Go's monotonic clock, it won't encounter issues during runtime. Clock backward problems only occur during restart initialization, therefore checking for clock backward needs to be performed during initialization.